### PR TITLE
[#161638457] :sparkles: Make use of yauzl-mac optional

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -7,13 +7,20 @@ var source = args[0]
 var dest = args[1] || process.cwd()
 var dryRun = process.env.EXTRACT_ZIP_DRY_RUN === 'true'
 var ignoreInvalidPaths = process.env.EXTRACT_ZIP_IGNORE_INVALID_PATHS === 'true'
+var supportMacArchiveUtility = process.env.EXTRACT_ZIP_SUPPORT_MAC_ARCHIVE_UTILITY === 'true'
 
 if (!source) {
   console.error('Usage: extract-zip foo.zip <targetDirectory>')
   process.exit(1)
 }
 
-extract(source, {dir: dest, dryRun: dryRun, ignoreInvalidPaths: ignoreInvalidPaths}, function (err) {
+extract(source, {
+  dir: dest,
+  dryRun: dryRun,
+  ignoreInvalidPaths: ignoreInvalidPaths,
+  supportMacArchiveUtility: supportMacArchiveUtility
+},
+function (err) {
   if (err) {
     console.error('error!', err)
     process.exit(1)

--- a/index.js
+++ b/index.js
@@ -37,7 +37,13 @@ module.exports = function (zipPath, opts, cb) {
       return !invalidPathRegex.test(err.message)
     }
 
-    yauzl.open(zipPath, {supportMacArchiveUtility: true, lazyEntries: true, autoClose: false, errorFilter: errorFilter}, function (err, zipfile) {
+    yauzl.open(zipPath, {
+      supportMacArchiveUtility: opts.supportMacArchiveUtility,
+      lazyEntries: true,
+      autoClose: false,
+      errorFilter: errorFilter
+    },
+    function (err, zipfile) {
       if (err) return cb(err)
 
       var cancelled = false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extract-zip",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "description": "unzip a zip file into a directory using 100% javascript",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Make `supportMacArchiveUtility` optional so we can try the normal extract first and then attempt a mac-archive-utility-compatible extract