### PR TITLE
:bug: Allow overwriting of symlinks

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,6 +228,18 @@ module.exports = function (zipPath, opts, cb) {
                 var link = data.toString()
                 debug('creating symlink', link, dest)
                 fs.symlink(link, dest, function (err) {
+                  if (err && err.code === 'EEXIST') {
+                    return fs.unlink(dest, function (err) {
+                      if (!err) {
+                        return fs.symlink(link, dest, function (err) {
+                          if (err) cancelled = true
+                          done(err)
+                        })
+                      }
+                      cancelled = true
+                      done(err)
+                    })
+                  }
                   if (err) cancelled = true
                   done(err)
                 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "extract-zip",
-  "version": "1.6.7",
+  "version": "1.6.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extract-zip",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "unzip a zip file into a directory using 100% javascript",
   "main": "index.js",
   "bin": {

--- a/test/test.js
+++ b/test/test.js
@@ -90,6 +90,24 @@ test('symlinks', function (t) {
   })
 })
 
+test('overwriting symlinks', function (t) {
+  t.plan(6)
+
+  tempExtract(t, 'symlinks', symlinkZip, function (dirPath) {
+    var symlink = path.join(dirPath, 'symlink', 'foo_symlink.txt')
+
+    extract(symlinkZip, {dir: dirPath}, function (err) {
+      t.false(err)
+      t.true(fs.existsSync(symlink), 'symlink created')
+
+      fs.lstat(symlink, function (err, stats) {
+        t.same(err, null, 'symlink can be stat\'d')
+        t.ok(stats.isSymbolicLink(), 'symlink is valid')
+      })
+    })
+  })
+})
+
 test('directories', function (t) {
   t.plan(8)
 
@@ -122,11 +140,10 @@ test('verify github zip extraction worked', function (t) {
 })
 
 test('callback called once', function (t) {
-  t.plan(4)
+  t.plan(3)
 
-  tempExtract(t, 'callback', symlinkZip, function (dirPath) {
-    // this triggers an error due to symlink creation
-    extract(symlinkZip, {dir: dirPath}, function (err) {
+  mkdtemp(t, 'broken-zip', function (dirPath) {
+    extract(brokenZip, {dir: dirPath}, function (err) {
       if (err) t.ok(true, 'error passed')
 
       t.ok(true, 'callback called')


### PR DESCRIPTION
This catches the `EEXIST` error that happens when attempting to overwrite a symlink, removes the symlink and tries again. This allows games on mac with symlinks to be updated (which is very common as Mac frameworks contain symlinks)